### PR TITLE
install minicompter.tll instead of minicomputer

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 OBJECTS = minicomputer.o
 LIBRARY = libminicomputer.so
-TTLS = minicomputer manifest.ttl
+TTLS = minicomputer.ttl manifest.ttl
 CC = gcc
 CFLAGS += -std=c99 -Wall -Wextra -fPIC
 INSTALLDIR = $(DESTDIR)/usr/lib/lv2/


### PR DESCRIPTION
the makefile tried to install minicomputer (which is not generated by the makefile) instead of minicomputer.ttl