### PR TITLE
Various fixes for Makefile and ttl files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,12 +1,12 @@
 OBJECTS = minicomputer.o
 LIBRARY = libminicomputer.so
-TTLS = minicomputer manifest.ttl
+TTLS = minicomputer.ttl manifest.ttl
 CC = gcc
 CFLAGS += -std=c99 -Wall -Wextra -fPIC
 INSTALLDIR = $(DESTDIR)/usr/lib/lv2/
 INSTALLNAME = minicomputer.lv2/
 $(LIBRARY) : $(OBJECTS)
-	$(CC) $(CFLAGS) $(OBJECTS) -shared -o $@
+	$(CC) $(CFLAGS) $(OBJECTS) -shared -o $@ -llo
 
 .SUFFIXES : .c .o
 

--- a/src/manifest.ttl
+++ b/src/manifest.ttl
@@ -1,6 +1,7 @@
 @prefix lv2:  <http://lv2plug.in/ns/lv2core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-<urn:malte.steiner:plugins:minicomputer.1> a lv2:Plugin;
+<http://malte.steiner.org/lv2/minicomputer>
+  a lv2:Plugin ;
   lv2:binary   <libminicomputer.so> ;
   rdfs:seeAlso <minicomputer.ttl> .

--- a/src/minicomputer.c
+++ b/src/minicomputer.c
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <pthread.h>
 #include "minicomputer.h"
 
 /**  FIXED

--- a/src/minicomputer.h
+++ b/src/minicomputer.h
@@ -219,7 +219,7 @@ typedef struct _minicomputer {
 	lo_server_thread st;
 } minicomputer;
 
-#define MINICOMPUTER_URI "urn:malte.steiner:plugins:minicomputer"
+#define MINICOMPUTER_URI "http://malte.steiner.org/lv2/minicomputer"
 
 static void connect_port_minicomputer(LV2_Handle instance, uint32_t port, void *data);
 

--- a/src/minicomputer.ttl
+++ b/src/minicomputer.ttl
@@ -1,77 +1,97 @@
-@prefix lv2:  <http://lv2plug.in/ns/lv2core#> .
-@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
-@prefix ev: <http://lv2plug.in/ns/ext/event#>.
-<urn:malte.steiner:plugins:minicomputer> a lv2:Plugin ;
-	a lv2:InstrumentPlugin;
-    doap:name "Minicomputer Synthesizer" ;
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix lv2:  <http://lv2plug.in/ns/lv2core#> .
+@prefix opts: <http://lv2plug.in/ns/ext/options#> .
+@prefix ev:   <http://lv2plug.in/ns/ext/event#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix unit: <http://lv2plug.in/ns/extensions/units#> .
+
+<http://malte.steiner.org/lv2/minicomputer>
+    a lv2:InstrumentPlugin, lv2:Plugin ;
+
+    lv2:optionalFeature <http://lv2plug.in/ns/lv2core#hardRTCapable> ;
+    
+    lv2:requiredFeature <http://lv2plug.in/ns/ext/event> ,
+                        <http://lv2plug.in/ns/ext/uri-map> ;
+	
+    lv2:port [
+        a lv2:AudioPort ;
+        a lv2:OutputPort ;
+        lv2:index 0 ;
+        lv2:symbol "out" ;
+        lv2:name "Audio Out" ;
+    ] ,
+    [
+        a lv2:InputPort ;
+        a ev:EventPort ;
+        lv2:index 1 ;
+        ev:supportsEvent <http://lv2plug.in/ns/ext/midi#MidiEvent> ;
+        lv2:symbol "midi" ;
+        lv2:name "MIDI Input" ;
+    ] ,
+    [
+        a lv2:InputPort ;
+        a lv2:ControlPort ;
+        lv2:index 2 ;
+        lv2:symbol "volume" ;
+        lv2:name "Volume" ;
+        lv2:default 1 ;
+        lv2:minimum 0 ;
+        lv2:maximum 2 ;
+    ] ,
+    [
+        a lv2:InputPort ;
+        a lv2:ControlPort ;
+        lv2:index 3 ;
+        lv2:symbol "osc1_fix_freq" ;
+        lv2:name "Fix Osc1 frequency" ;
+        lv2:portProperty lv2:toggled ;
+        lv2:default 0 ;
+    ] ,
+    [
+        a lv2:InputPort ;
+        a lv2:ControlPort ;
+        lv2:index 4 ;
+        lv2:symbol "osc1_fixed_freq" ;
+        lv2:name "Osc 1 Fixed Frequency" ;
+        lv2:default 0 ;
+        lv2:minimum 0 ;
+        lv2:maximum 1000 ;
+    ] ,
+    [
+        a lv2:InputPort ;
+        a lv2:ControlPort ;
+        lv2:index 5 ;
+        lv2:symbol "osc1_tuned_freq" ;
+        lv2:name "Osc 1 Transposition" ;
+        lv2:default 1 ;
+        lv2:minimum 0 ;
+        lv2:maximum 17 ;
+    ] ,
+    [
+        a lv2:InputPort ;
+        a lv2:ControlPort ;
+        lv2:index 6 ;
+        lv2:symbol "osc1_tuned_freq" ;
+        lv2:name "Osc 1 Transposition" ;
+        lv2:default 1 ;
+        lv2:minimum 0 ;
+        lv2:maximum 17 ;
+    ] ;
+    
+    doap:name "Minicomputer Synthetizer" ;
     doap:license <http://usefulinc.com/doap/licenses/gpl> ;
     doap:developer [
       foaf:name "Malte Steiner";
+      foaf:homepage <https://github.com/jeremysalwen/Minicomputer-LV2> ;
     ] ;
+    
     doap:maintainer [ 
       foaf:name "Jeremy Salwen";
       foaf:mbox <mailto:jeremysalwen@gmail.com>;
+      foaf:homepage <https://github.com/jeremysalwen/Minicomputer-LV2> ;
     ] ;
-    lv2:requiredFeature <http://lv2plug.in/ns/ext/event> ;
-    lv2:requiredFeature <http://lv2plug.in/ns/ext/uri-map> ;
-	
-    lv2:port [
-    a lv2:AudioPort ;
-    a lv2:OutputPort ;
-    lv2:index 0 ;
-    lv2:symbol "out" ;
-    lv2:name "Audio Out" ;
-    ],[
-    a lv2:InputPort;
-    a ev:EventPort;
-    lv2:index 1 ;
-    ev:supportsEvent <http://lv2plug.in/ns/ext/midi#MidiEvent>;
-    lv2:symbol "midi";
-    lv2:name "MIDI Input";
-    ],[
-    a lv2:InputPort;
-    a lv2:ControlPort;
-    lv2:index 2;
-    lv2:symbol "volume";
-    lv2:name "Volume";
-    lv2:default 1;
-    lv2:minimum 0;
-    lv2:maximum 2;
-    ],[
-    a lv2:InputPort;
-    a lv2:ControlPort;
-    lv2:index 3;
-    lv2:symbol "osc1_fix_freq";
-    lv2:name "Fix Osc1 frequency";
-    lv2:portProperty lv2:toggled;
-    lv2:default 0;
-    ],[
-    a lv2:InputPort;
-    a lv2:ControlPort;
-    lv2:index 4;
-    lv2:symbol "osc1_fixed_freq";
-    lv2:name "Osc 1 Fixed Frequency";
-    lv2:default 0;
-    lv2:minimum 0;
-    lv2:maximum 1000;
-    ],[
-    a lv2:InputPort;
-    a lv2:ControlPort;
-    lv2:index 5;
-    lv2:symbol "osc1_tuned_freq";
-    lv2:name "Osc 1 Transposition";
-    lv2:default 1;
-    lv2:minimum 0;
-    lv2:maximum 17;
-    ],[
-    a lv2:InputPort;
-    a lv2:ControlPort;
-    lv2:index 6;
-    lv2:symbol "osc1_tuned_freq";
-    lv2:name "Osc 1 Transposition";
-    lv2:default 1;
-    lv2:minimum 0;
-    lv2:maximum 17;
-    ]
-    .
+    
+    lv2:microVersion 1 ;
+    lv2:minorVersion 0 .


### PR DESCRIPTION
With these fixes, minicomputer LV2 builds.
I have now new warnings related to deprecated features. I will have a look later:
```
$ lv2lint http://malte.steiner.org/lv2/minicomputer
lv2lint 0.2.0
Copyright (c) 2016-2019 Hanspeter Portner (dev@open-music-kontrollers.ch)
Released under Artistic License 2.0 by Open Music Kontrollers
<http://malte.steiner.org/lv2/minicomputer>
    [FAIL]  Features
              lv2:[optional|required]Feature <http://lv2plug.in/ns/ext/event> not valid
              seeAlso: <http://lv2plug.in/ns/lv2core#Feature>
    [FAIL]  URI-Map
              uri-map is deprecated, use urid:map instead
              seeAlso: <http://lv2plug.in/ns/ext/uri-map>
  {1 : midi}
    [FAIL]  Event Port
              lv2:EventPort is deprecated, use atom:AtomPort instead
              seeAlso: <http://lv2plug.in/ns/ext/event#EventPort>

```